### PR TITLE
Raise CommandError instead is SystemExit

### DIFF
--- a/django_probes/management/commands/wait_for_database.py
+++ b/django_probes/management/commands/wait_for_database.py
@@ -2,7 +2,7 @@
 FILE: django_probes/management/commands/wait_for_database.py
 """
 from time import sleep, time
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db import connection
 from django.db.utils import OperationalError
 
@@ -90,4 +90,4 @@ class Command(BaseCommand):
         try:
             wait_for_database(**options)
         except TimeoutError as err:
-            raise SystemExit(err)
+            raise CommandError(err)


### PR DESCRIPTION
Using CommandError is the 'preferred way' for custom Commands, it will print the message and do the sys.exit(1).

Makes it a bit nicer to use from python code (e.g through `django.core.management.call_command`),
avoids needing to catch SystemExit.