### PR TITLE
Skip system checks

### DIFF
--- a/django_probes/management/commands/wait_for_database.py
+++ b/django_probes/management/commands/wait_for_database.py
@@ -63,6 +63,7 @@ class Command(BaseCommand):
     the command exits with an error status after reaching a timeout.
     """
     help = 'Probes for database availability'
+    requires_system_checks = False
 
     def add_arguments(self, parser):
         parser.add_argument('--timeout', '-t', type=int, default=180,


### PR DESCRIPTION
Certain Django checks require a database connection, so these would fail
before the command is run. So skip these for wait_for_database command.