### PR TITLE
Test query database compatibility

### DIFF
--- a/django_probes/management/commands/wait_for_database.py
+++ b/django_probes/management/commands/wait_for_database.py
@@ -28,7 +28,7 @@ def wait_for_database(**opts):
         # loop until we have a database connection or we run into a timeout
         while True:
             try:
-                connection.cursor().execute('SELECT')
+                connection.cursor().execute('SELECT 1')
                 if not conn_alive_start:
                     conn_alive_start = time()
                 break


### PR DESCRIPTION
Use 'SELECT 1', it's the more compatible. This works on most commonly
used databases, like postgreSQL, mysql, mariadb, mssql (and probably
others). But does _not_ work on, for example, oracle (and probably
others).

This is a, minimal impact, 'quick fix', better solution would be to go
through Django's database backend 'is_usable' method.

Fixes issue #3