### PR TITLE
Database (alias) selection parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,3 +87,5 @@ if needed:
     delay between checks when database is down (seconds), default: 2
 :--wait-when-alive, -a:
     delay between checks when database is up (seconds), default: 1
+:--database:
+    Nominates a database to wait for, default: default

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -20,6 +20,7 @@ CLI_PARAMS = {
     'wait_when_alive': 1,
     'stable': 3,
     'timeout': 1,
+    'database': 'default',
 }
 
 


### PR DESCRIPTION
Add (optional) command line parameter (`--database`) to select a database
by its alias.

Kept it the same as Django's own commands parameter for this.

See #4
