### PR TITLE
print error to stderr and flush to screen

### DIFF
--- a/django_probes/management/commands/wait_for_database.py
+++ b/django_probes/management/commands/wait_for_database.py
@@ -1,6 +1,7 @@
 """
 FILE: django_probes/management/commands/wait_for_database.py
 """
+import sys
 from time import sleep, time
 from django.core.management.base import BaseCommand, CommandError
 from django.db import connections, DEFAULT_DB_ALIAS
@@ -44,11 +45,12 @@ def wait_for_database(**opts):
 
                 err_message = str(err).strip()
                 print('Waiting for database (cause: {msg}) ... {elapsed}s'.
-                      format(msg=err_message, elapsed=elapsed_time))
+                      format(msg=err_message, elapsed=elapsed_time),
+                      file=sys.stderr, flush=True)
                 sleep(wait_for_db_seconds)
 
         uptime = int(time() - conn_alive_start)
-        print('Connection alive for > {}s'.format(uptime))
+        print('Connection alive for > {}s'.format(uptime), flush=True)
 
         if uptime >= stable_for_seconds:
             break


### PR DESCRIPTION
depending on configuration (eg, for me, running these in docker) the stdout/err is buffered by default and nothing comes up.

adding flush=True will ... at least show up immediately.