### PR TITLE
Migrate to GitHub Actions, support Python 3.9 + Django 3.1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,30 @@
+name: Check
+
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env:
+        - flake8
+        - pylint
+        - bandit
+        - readme
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+    - name: Install prerequisites
+      run: python -m pip install --upgrade setuptools pip wheel tox
+    - name: Run ${{ matrix.env }}
+      run: tox -e ${{ matrix.env }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install prerequisites
+        run: python -m pip install --upgrade pip setuptools twine wheel
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
+      - name: Upload to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: twine upload dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,36 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+    - master
+  push:
+    branches:
+    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        python-version:
+        - '3.6'
+        - '3.7'
+        - '3.8'
+        - '3.9'
+        django-version:
+        - '2.2'
+        - '3.0'
+        - '3.1'
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install prerequisites
+      run: python -m pip install --upgrade setuptools pip wheel tox-gh-actions
+    - name: Run tests (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
+      run: tox
+      env:
+        DJANGO: ${{ matrix.django-version }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, VSHN AG, info@vshn.ch
+Copyright (c) 2019-2020 Peter Bittner
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Django-probes |latest-version|
 ==============================
 
-|build-status| |python-support| |license|
+|checks-status| |tests-status| |python-support| |license|
 
 Provides a Django management command to check whether the primary database
 is ready to accept connections.
@@ -22,15 +22,18 @@ specific container just for running the database readiness check.
 .. |latest-version| image:: https://img.shields.io/pypi/v/django-probes.svg
    :alt: Latest version on PyPI
    :target: https://pypi.org/project/django-probes
-.. |build-status| image:: https://img.shields.io/travis/vshn/django-probes/master.svg
-   :alt: Build status
-   :target: https://travis-ci.org/vshn/django-probes
+.. |checks-status| image:: https://img.shields.io/github/workflow/status/painless-software/django-probes/Check/master?label=Check&logo=github
+   :alt: GitHub Workflow Status
+   :target: https://github.com/painless-software/django-probes/actions?query=workflow%3ACheck
+.. |tests-status| image:: https://img.shields.io/github/workflow/status/painless-software/django-probes/Test/master?label=Test&logo=github
+   :alt: GitHub Workflow Status
+   :target: https://github.com/painless-software/django-probes/actions?query=workflow%3ATest
 .. |python-support| image:: https://img.shields.io/pypi/pyversions/django-probes.svg
    :alt: Python versions
    :target: https://pypi.org/project/django-probes
 .. |license| image:: https://img.shields.io/pypi/l/django-probes.svg
    :alt: Software license
-   :target: https://github.com/vshn/django-probes/blob/master/LICENSE
+   :target: https://github.com/painless-software/django-probes/blob/master/LICENSE
 
 .. _Init Container: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 

--- a/django_probes/__init__.py
+++ b/django_probes/__init__.py
@@ -4,5 +4,5 @@ Make Django wait until database is ready. Probes for Docker and Kubernetes.
 __author__ = 'Peter Bittner'
 __email__ = 'django@bittner.it'
 __url__ = 'https://github.com/painless-software/django-probes'
-__version__ = '1.5.0'
+__version__ = '1.6.0'
 __license__ = 'BSD-3-Clause'

--- a/django_probes/__init__.py
+++ b/django_probes/__init__.py
@@ -1,8 +1,8 @@
 """
 Make Django wait until database is ready. Probes for Docker and Kubernetes.
 """
-__author__ = 'VSHN AG'
-__email__ = 'tech@vshn.ch'
-__url__ = 'https://github.com/vshn/django-probes'
+__author__ = 'Peter Bittner'
+__email__ = 'django@bittner.it'
+__url__ = 'https://github.com/painless-software/django-probes'
 __version__ = '1.5.0'
 __license__ = 'BSD-3-Clause'

--- a/django_probes/management/commands/wait_for_database.py
+++ b/django_probes/management/commands/wait_for_database.py
@@ -38,7 +38,8 @@ def wait_for_database(**opts):
                 elapsed_time = int(time() - start)
                 if elapsed_time >= timeout_seconds:
                     raise TimeoutError(
-                        'Could not establish database connection.')
+                        'Could not establish database connection.'
+                        ) from err
 
                 err_message = str(err).strip()
                 print('Waiting for database (cause: {msg}) ... {elapsed}s'.
@@ -97,4 +98,4 @@ class Command(BaseCommand):
         try:
             wait_for_database(**options)
         except TimeoutError as err:
-            raise CommandError(err)
+            raise CommandError(err) from err

--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,11 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,10 @@
-# tox (https://tox.readthedocs.io/) is a tool for running tests
-# Run tests in multiple virtualenvs.
-
 [tox]
 envlist =
     flake8
     pylint
     bandit
     # Python/Django combinations that are officially supported
-    py{35,36,37,38}-django22
-    py{36,37,38}-django30
+    py{36,37,38,39}-django{22,30,31}
     readme
     clean
 
@@ -17,10 +13,11 @@ description = Unit tests
 deps =
     pytest-django
     pytest-pythonpath
+    psycopg2-binary
     django22: Django>=2.2,<3.0
     django30: Django>=3.0,<3.1
-    psycopg2-binary
-commands = pytest
+    django31: Django>=3.1,<3.2
+commands = pytest {posargs}
 
 [testenv:bandit]
 description = PyCQA security linter
@@ -31,14 +28,14 @@ commands = bandit {posargs:-r --ini tox.ini}
 description = Remove Python bytecode and other debris
 deps = pyclean
 commands =
-    py3clean -v {toxinidir}
+    pyclean -v {toxinidir}
     rm -rf .tox/ django_probes.egg-info/ build/ dist/
 whitelist_externals =
     rm
 
 [testenv:flake8]
 description = Static code analysis and code style
-deps = flake8
+deps = flake8-django
 commands = flake8 {posargs}
 
 [testenv:pylint]
@@ -55,10 +52,18 @@ commands =
     {envpython} setup.py -q sdist bdist_wheel
     twine check dist/*
 
-[travis:env]
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+
+[gh-actions:env]
 DJANGO =
     2.2: django22
     3.0: django30
+    3.1: django31
 
 [bandit]
 exclude = .cache,.git,.tox,build,dist,tests


### PR DESCRIPTION
Modernizes the project setup:

- Migrate from now desperately slow Travis-CI to GitHub Actions
- Cover Python 3.9 and Django 3.1, drop Python 3.5 in test matrix
- Update external references after moving from @vshn to @painless-software