### PR TITLE
Consolidate linting and build process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,12 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: '3.8'
-      - name: Install prerequisites
-        run: python -m pip install --upgrade pip setuptools twine wheel
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools build twine wheel
       - name: Build package
-        run: python setup.py sdist bdist_wheel
+        run: python -m build
       - name: Upload to PyPI
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
     - main
 
 jobs:
-  test:
+  python-django:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [tool.bandit]
-# Exclude/ignore of files is currently broken in Bandit.
+# Exclude/ignore of files and TOML reading is currently broken in Bandit
+exclude = [".cache",".git",".github",".tox","build","dist","tests"]
 
 [tool.black]
 color = true

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'kubernetes',
     ],
     classifiers=[
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Framework :: Django',

--- a/tests/testproject/settings.py
+++ b/tests/testproject/settings.py
@@ -8,16 +8,11 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/stable/ref/settings/
 """
 
-from pathlib import Path
-
-BASE_DIR = Path(__file__).resolve().parent.parent
-
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/stable/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'b1h-uedc(&7Tu@7ecuk*x3l(93-=r*Za=wzzod@%)zn=v7u+_l'
+SECRET_KEY = 'insecure-random-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -61,9 +56,9 @@ TEMPLATES = [
     },
 ]
 
-ROOT_URLCONF = 'test_project.urls'
+ROOT_URLCONF = 'testproject.urls'
 
-WSGI_APPLICATION = 'test_project.wsgi.application'
+WSGI_APPLICATION = 'testproject.wsgi.application'
 
 
 # Database
@@ -85,8 +80,6 @@ LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 
 USE_I18N = True
-
-USE_L10N = True
 
 USE_TZ = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,20 @@ envlist =
     readme
     clean
 
+[gh-actions]
+python =
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+
+[gh-actions:env]
+DJANGO =
+    2.2: django22
+    3.2: django32
+    4.0: django40
+
 [testenv]
 description = Unit tests
 deps =
@@ -29,7 +43,7 @@ commands =
 [testenv:bandit]
 description = PyCQA security linter
 deps = bandit
-commands = bandit {posargs:-r django_probes}
+commands = bandit -v {posargs:-r django_probes}
 
 [testenv:clean]
 description = Remove Python bytecode and other debris
@@ -59,27 +73,12 @@ commands = pylint {posargs:django_probes setup}
 
 [testenv:readme]
 description = Ensure README renders on PyPI
-deps = twine
+deps =
+    build
+    twine
 commands =
-    {envpython} setup.py -q sdist bdist_wheel
+    python -m build
     twine check dist/*
-
-[gh-actions]
-python =
-    3.6: py36
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310
-
-[gh-actions:env]
-DJANGO =
-    2.2: django22
-    3.2: django32
-    4.0: django40
-
-[bandit]
-exclude = .cache,.git,.tox,build,dist,tests
 
 [flake8]
 exclude = .cache,.git,.tox,build,dist,django_probes.egg-info


### PR DESCRIPTION
PyPA now discourages installing and building via `setup.py` and [encourages using `build` and `twine`](https://packaging.python.org/en/latest/tutorials/packaging-projects/#generating-distribution-archives) instead.