### PR TITLE
Activate pylint-django plugin for linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IDEs & editors
 /.idea/
+/.vscode/
 
 # cache
 *.py[cod]
@@ -21,6 +22,7 @@ __pycache__/
 /pytestdebug.log
 /tests/*-report.json
 /tests/*-report.xml
+/tests/testproject.sqlite
 .coverage
 
 Pipfile.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ color_output = true
 profile = "black"
 
 [tool.pylint.master]
+django-settings-module = "tests.testproject.settings"
+load-plugins = ["pylint_django"]
 output-format = "colorized"
 
 [tool.pytest.ini_options]

--- a/tests/testproject/settings.py
+++ b/tests/testproject/settings.py
@@ -7,6 +7,9 @@ https://docs.djangoproject.com/en/stable/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/stable/ref/settings/
 """
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/stable/howto/deployment/checklist/
@@ -66,9 +69,8 @@ WSGI_APPLICATION = 'testproject.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'HOST': 'db.example.com',
-        'NAME': 'database',
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'tests' / 'testproject.sqlite',
     }
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
 commands =
-    coverage run -m pytest
+    coverage run -m pytest {posargs}
     coverage xml
     coverage report
 
@@ -49,8 +49,8 @@ commands = bandit -v {posargs:-r django_probes}
 description = Remove Python bytecode and other debris
 deps = pyclean
 commands =
-    pyclean .
-    rm -rf .coverage .tox/ django_probes.egg-info/ build/ dist/ tests/coverage-report.xml tests/unittests-report.xml
+    pyclean {posargs:.}
+    rm -rf .coverage .tox/ django_probes.egg-info/ build/ dist/ tests/coverage-report.xml tests/unittests-report.xml tests/testproject.sqlite
 allowlist_externals =
     rm
 
@@ -69,7 +69,8 @@ description = Check for errors and code smells
 deps =
     django
     pylint-django
-commands = pylint {posargs:django_probes setup}
+commands =
+    pylint {posargs:django_probes setup}
 
 [testenv:readme]
 description = Ensure README renders on PyPI


### PR DESCRIPTION
The Pylint plugin [pylint-django](https://pypi.org/project/pylint-django/) needs to be activated and configured to work.