### PR TITLE
Remove obsolete pythonpath Pytest plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,4 +21,4 @@ output-format = "colorized"
 addopts = "--junitxml=tests/unittests-report.xml --color=yes --verbose"
 DJANGO_SETTINGS_MODULE = "testproject.settings"
 python_files = ["tests.py","test_*.py","*_tests.py"]
-python_paths = ["tests"]
+pythonpath = ["tests"]

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,6 @@ description = Unit tests
 deps =
     coverage[toml]
     pytest-django
-    pytest-pythonpath
-    psycopg2-binary
     django22: Django>=2.2,<3.0
     django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1


### PR DESCRIPTION
Replaced by `pythonpath` option in Pytest settings. See the related [Pytest docs](https://docs.pytest.org/en/7.0.x/reference/reference.html#confval-pythonpath).