### PR TITLE
Exclude unsupported Python+Django combinations in GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,11 @@ jobs:
         - '3.2'
         - '4.0'
         - '4.1'
+        exclude:
+        - { django-version: '4.0', python-version: '3.6' }
+        - { django-version: '4.0', python-version: '3.7' }
+        - { django-version: '4.1', python-version: '3.6' }
+        - { django-version: '4.1', python-version: '3.7' }
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,9 @@ envlist =
     pylint
     bandit
     # Python/Django combinations that are officially supported
-    py{36,37,38,39,310}-django{32}
-    py{38,39,310}-django{40,41}
+    py{36,37,38,39,310}-django32
+    py{38,39,310}-django40
+    py{38,39,310}-django41
     readme
     clean
 


### PR DESCRIPTION
The GHA test matrix spawns jobs that are not defined in the Tox configuration. We can fix this.

This is a follow-up on #25.