### PR TITLE
Add a --command argument, allowing to directly call a Django command …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,3 +109,6 @@ if needed:
     delay between checks when database is up (seconds), default: ``1``
 :--database:
     which database of ``settings.DATABASES`` to wait for, default: ``default``
+:--command, -c:
+    execute this Django command when the database is ready.
+    This option can be used multiple times: ``wait_for_database -c 'migrate' -c 'runserver --skip-checks'``

--- a/README.rst
+++ b/README.rst
@@ -110,5 +110,5 @@ if needed:
 :--database:
     which database of ``settings.DATABASES`` to wait for, default: ``default``
 :--command, -c:
-    execute this Django command when the database is ready.
-    This option can be used multiple times: ``wait_for_database -c 'migrate' -c 'runserver --skip-checks'``
+    execute this Django management command when the database is ready.
+    This option can be used multiple times, e.g. ``wait_for_database -c 'migrate' -c 'runserver --skip-checks'``

--- a/django_probes/management/commands/wait_for_database.py
+++ b/django_probes/management/commands/wait_for_database.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
                                  'database.')
         parser.add_argument("--command", "-c", default=[],
                             action="append", dest='command',
-                            help='execute this command when database is up (can be repeated multiple times).')
+                            help='execute this management command when database is up (can be repeated multiple times).')
 
     def handle(self, *args, **options):
         """
@@ -105,5 +105,6 @@ class Command(BaseCommand):
         except TimeoutError as err:
             raise CommandError(err) from err
         for command in commands:
-            command_list = shlex.split(command)
-            call_command(command_list[0], *command_list[1:])
+            parts = shlex.split(command)
+            executable, params = parts[0], parts[1:]
+            call_command(executable, *params)

--- a/django_probes/management/commands/wait_for_database.py
+++ b/django_probes/management/commands/wait_for_database.py
@@ -90,20 +90,20 @@ class Command(BaseCommand):
                             help='which database of `settings.DATABASES` '
                                  'to wait for. Defaults to the "default" '
                                  'database.')
-        parser.add_argument("--command", "-c", default=None,
-                            action="store", dest='command',
-                            help='execute this command when database is up')
+        parser.add_argument("--command", "-c", default=[],
+                            action="append", dest='command',
+                            help='execute this command when database is up (can be repeated multiple times).')
 
     def handle(self, *args, **options):
         """
         Wait for a database connection to come up. Exit with error
         status when a timeout threshold is surpassed.
         """
-        command = options.pop("command", None)
+        commands = options.pop("command", [])
         try:
             wait_for_database(**options)
         except TimeoutError as err:
             raise CommandError(err) from err
-        if command:
+        for command in commands:
             command_list = shlex.split(command)
             call_command(command_list[0], *command_list[1:])


### PR DESCRIPTION
…when databases are ready, without patching the command itself and without loading the django machinery twice.